### PR TITLE
更新midi_prase获取链接

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -12,4 +12,4 @@ requests==2.32.2
 PyYAML==6.0.2
 pygame==2.6.1
 websockets==13.1
-midi_prase==0.0.7
+https://github.com/qaqFei/midi_parse/archive/refs/heads/main.zip


### PR DESCRIPTION
midi_prase 并未发布到Pypi，临时改为从GitHub获取最新版Zip Archive安装